### PR TITLE
cd_window_update_widget_plug_name(): do not leak plug_name

### DIFF
--- a/libcolord-gtk/cd-window.c
+++ b/libcolord-gtk/cd-window.c
@@ -376,7 +376,7 @@ cd_window_update_widget_plug_name (CdWindow *window,
 				   GtkWidget *widget)
 {
 	CdWindowPrivate *priv = window->priv;
-	const gchar *plug_name;
+	gchar *plug_name;
 	GdkScreen *screen;
 	GdkWindow *gdk_window;
 	gint monitor_num;
@@ -390,12 +390,14 @@ cd_window_update_widget_plug_name (CdWindow *window,
 	plug_name = gdk_screen_get_monitor_plug_name (screen, monitor_num);
 
 	/* ignoring MAP as plug_name has not changed */
-	if (g_strcmp0 (plug_name, priv->plug_name) == 0)
+	if (g_strcmp0 (plug_name, priv->plug_name) == 0) {
+		g_free (plug_name);
 		return;
+	}
 
 	/* refresh data */
 	g_free (priv->plug_name);
-	priv->plug_name = g_strdup (plug_name);
+	priv->plug_name = plug_name;
 	if (priv->device != NULL) {
 		g_object_unref (priv->device);
 		priv->device = NULL;


### PR DESCRIPTION
I was working on fixing leaks in darktable, and found this.

I have installed colord-gtk with this change into /usr/local, and verified that this fixes the LeakSanitizer complaint, makes darktable free of any colord-related (colord and colord-gtk) leaks (or, at least i was not able to trigger others...) and does not seem to cause any side-effects (at least so far).

[gdk_screen_get_monitor_plug_name() "Returns a newly-allocated string containing the name of the monitor"](https://developer.gnome.org/gdk3/stable/GdkScreen.html#gdk-screen-get-monitor-plug-name)
which means, now it is our duty to g_free() it.

Also, no reason to g_strdup() it.

Fixes several LeakSanitizer-detected leaks like:
```
Direct leak of 36 byte(s) in 6 object(s) allocated from:
    0 0x7f4b64a7c74f in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x5474f)
    1 0x7f4b61e17799 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4f799)
    2 0x7f4b61e3012e in g_strdup (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x6812e)
    3 0x7f4b5d3a6078 in cd_window_update_widget_plug_name /home/lebedevri/src/colord-gtk/libcolord-gtk/cd-window.c:390
    4 0x7f4b5d3a6cdd in cd_window_get_profile /home/lebedevri/src/colord-gtk/libcolord-gtk/cd-window.c:452
    5 0x7f4b64456504 in dt_ctl_set_display_profile /home/lebedevri/darktable/src/control/control.c:214
    6 0x7f4b64585c87 in configure /home/lebedevri/darktable/src/gui/gtk.c:611
```