### PR TITLE
build: Migrate to gettext

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,10 +32,7 @@ EXTRA_DIST =						\
 	README						\
 	NEWS						\
 	autogen.sh					\
-	config.h					\
-	intltool-extract.in				\
-	intltool-merge.in				\
-	intltool-update.in
+	config.h
 
 MAINTAINERCLEANFILES =					\
 	$(srcdir)/INSTALL				\

--- a/autogen.sh
+++ b/autogen.sh
@@ -29,7 +29,7 @@ fi
 
 gtkdocize || exit $?
 autopoint --force
-ACLOCAL="${ACLOCAL-aclocal} $ACLOCAL_FLAGS"  AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
+ACLOCAL="${ACLOCAL-aclocal} $ACLOCAL_FLAGS" autoreconf --force --install --verbose
 
 cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,6 @@ AC_PROG_CC
 AC_PROG_INSTALL
 LT_INIT
 AM_PROG_CC_C_O
-IT_PROG_INTLTOOL([0.35.0])
 AC_PATH_PROG(XSLTPROC, xsltproc)
 
 dnl ---------------------------------------------------------------------------
@@ -111,7 +110,7 @@ AC_SUBST(WARNINGFLAGS_C)
 dnl ---------------------------------------------------------------------------
 dnl - gettext stuff
 dnl ---------------------------------------------------------------------------
-AM_GNU_GETTEXT_VERSION([0.17])
+AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
 
 GETTEXT_PACKAGE=AC_PACKAGE_NAME

--- a/contrib/colord-gtk.spec.in
+++ b/contrib/colord-gtk.spec.in
@@ -9,10 +9,9 @@ URL:       http://www.freedesktop.org/software/colord/
 Source0:   http://www.freedesktop.org/software/colord/releases/%{name}-%{version}.tar.xz
 
 BuildRequires: docbook-utils
-BuildRequires: gettext
+BuildRequires: gettext >= 0.19.8
 BuildRequires: glib2-devel
 BuildRequires: colord-devel
-BuildRequires: intltool
 BuildRequires: lcms2-devel >= 2.2
 BuildRequires: gobject-introspection-devel
 BuildRequires: vala-tools

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,6 +1,5 @@
 *.gmo
 *.header
-.intltool-merge-cache
 Makefile.in.in
 Makevars.template
 POTFILES

--- a/po/Makevars
+++ b/po/Makevars
@@ -1,0 +1,78 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = $(PACKAGE)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=g_dngettext:2,3 --add-comments
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER = The colord-gtk authors
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS = https://github.com/hughsie/colord-gtk/issues
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = yes
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = no
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = no


### PR DESCRIPTION
Recent gettext version can extract and merge back strings from and to
various file formats, no need for  intltool anymore.

https://wiki.gnome.org/Initiatives/GnomeGoals/GettextMigration

https://github.com/hughsie/colord-gtk/issues/5