### PR TITLE
Make introspection optional in meson

### DIFF
--- a/libcolord-gtk/meson.build
+++ b/libcolord-gtk/meson.build
@@ -61,6 +61,7 @@ pkgg.generate(
   description : 'colord-gtk is GTK integration for libcolord',
 )
 
+if get_option('introspection')
 libcolord_gtk_gir = gnome.generate_gir(
   colord_gtk,
   sources : [
@@ -97,6 +98,7 @@ libcolord_gtk_gir = gnome.generate_gir(
   ],
   install : true
 )
+endif
 
 if get_option('vapi')
   gnome.generate_vapi(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('gtk2', type : 'boolean', value : false, description : 'Build Gtk2 library')
+option('introspection', type : 'boolean', value : true, description : 'Build gobject-introspection typelib files')
 option('vapi', type : 'boolean', value : false, description : 'Build vala bindings')
 option('tests', type : 'boolean', value : true, description : 'Build self tests')
 option('man', type : 'boolean', value : true, description : 'Generate man pages')


### PR DESCRIPTION
Switching the build system to meson lost the option to disable introspection.  This is helpful e.g. when cross-compiling so the library can still be installed without having to do all sorts of QEMU tricks to make target system typelib files.