### PR TITLE
man: Add the source attribute for the man page

### DIFF
--- a/man/cd-convert.xml
+++ b/man/cd-convert.xml
@@ -18,6 +18,7 @@
   <refmeta>
     <refentrytitle>cd-convert</refentrytitle>
     <manvolnum>1</manvolnum>
+    <refmiscinfo class="source">colord-gtk</refmiscinfo>
     <refmiscinfo class="manual">User Commands</refmiscinfo>
   </refmeta>
   <refnamediv>


### PR DESCRIPTION
Without it, the man page contains "FIXME: source" at the left-bottom corner.